### PR TITLE
Fix deprecate inline

### DIFF
--- a/addons.tf
+++ b/addons.tf
@@ -53,7 +53,7 @@ module "eks_blueprints_addons" {
     chart_version = try(var.kube_prometheus_stack_version, local.kube_prometheus_stack["version"])
     values = setunion(var.config_prometheus_stack, [templatefile("${path.module}/k8s/helm/kube_prometheus_stack/values.yaml", {
       ingress_enabled    = var.enable_grafana_ingress
-      tags_system            = var.tags["System"]
+      tags_system        = var.tags["System"]
       grafana_password   = try(random_password.default["grafana"].result, "")
       ingress_certs_arn  = var.certificate
       ingress_name       = local.grafana_ingress

--- a/iam_alb_controller.tf
+++ b/iam_alb_controller.tf
@@ -22,240 +22,242 @@ resource "aws_iam_role" "albrole" {
       }
     ]
   })
-  inline_policy {
-    name = "LoadBalance-conroller" ## [Hidden Policy name]: Permission
-    policy = jsonencode({
-      "Version" : "2012-10-17",
-      "Statement" : [
-        {
-          "Action" : "iam:CreateServiceLinkedRole",
-          "Condition" : {
-            "StringEquals" : {
-              "iam:AWSServiceName" : "elasticloadbalancing.amazonaws.com"
-            }
+}
+# inline_policy {
+resource "aws_iam_role_policy" "albrole_policy" {
+  name = "LoadBalance-conroller" ## [Hidden Policy name]: Permission
+  role = aws_iam_role.albrole.name
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Action" : "iam:CreateServiceLinkedRole",
+        "Condition" : {
+          "StringEquals" : {
+            "iam:AWSServiceName" : "elasticloadbalancing.amazonaws.com"
+          }
+        },
+        "Effect" : "Allow",
+        "Resource" : "*"
+      },
+      {
+        "Action" : [
+          "elasticloadbalancing:DescribeTargetHealth",
+          "elasticloadbalancing:DescribeTargetGroups",
+          "elasticloadbalancing:DescribeTargetGroupAttributes",
+          "elasticloadbalancing:DescribeTags",
+          "elasticloadbalancing:DescribeSSLPolicies",
+          "elasticloadbalancing:DescribeRules",
+          "elasticloadbalancing:DescribeLoadBalancers",
+          "elasticloadbalancing:DescribeLoadBalancerAttributes",
+          "elasticloadbalancing:DescribeListeners",
+          "elasticloadbalancing:DescribeListenerCertificates",
+          "ec2:GetCoipPoolUsage",
+          "ec2:DescribeVpcs",
+          "ec2:DescribeVpcPeeringConnections",
+          "ec2:DescribeTags",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeInternetGateways",
+          "ec2:DescribeInstances",
+          "ec2:DescribeCoipPools",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeAddresses",
+          "ec2:DescribeAccountAttributes"
+        ],
+        "Effect" : "Allow",
+        "Resource" : "*"
+      },
+      {
+        "Action" : [
+          "wafv2:GetWebACLForResource",
+          "wafv2:GetWebACL",
+          "wafv2:DisassociateWebACL",
+          "wafv2:AssociateWebACL",
+          "waf-regional:GetWebACLForResource",
+          "waf-regional:GetWebACL",
+          "waf-regional:DisassociateWebACL",
+          "waf-regional:AssociateWebACL",
+          "shield:GetSubscriptionState",
+          "shield:DescribeProtection",
+          "shield:DeleteProtection",
+          "shield:CreateProtection",
+          "iam:ListServerCertificates",
+          "iam:GetServerCertificate",
+          "cognito-idp:DescribeUserPoolClient",
+          "acm:ListCertificates",
+          "acm:DescribeCertificate"
+        ],
+        "Effect" : "Allow",
+        "Resource" : "*"
+      },
+      {
+        "Action" : [
+          "ec2:RevokeSecurityGroupIngress",
+          "ec2:AuthorizeSecurityGroupIngress"
+        ],
+        "Effect" : "Allow",
+        "Resource" : "*"
+      },
+      {
+        "Action" : "ec2:CreateSecurityGroup",
+        "Effect" : "Allow",
+        "Resource" : "*"
+      },
+      {
+        "Action" : "ec2:CreateTags",
+        "Condition" : {
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
           },
-          "Effect" : "Allow",
-          "Resource" : "*"
+          "StringEquals" : {
+            "ec2:CreateAction" : "CreateSecurityGroup"
+          }
         },
-        {
-          "Action" : [
-            "elasticloadbalancing:DescribeTargetHealth",
-            "elasticloadbalancing:DescribeTargetGroups",
-            "elasticloadbalancing:DescribeTargetGroupAttributes",
-            "elasticloadbalancing:DescribeTags",
-            "elasticloadbalancing:DescribeSSLPolicies",
-            "elasticloadbalancing:DescribeRules",
-            "elasticloadbalancing:DescribeLoadBalancers",
-            "elasticloadbalancing:DescribeLoadBalancerAttributes",
-            "elasticloadbalancing:DescribeListeners",
-            "elasticloadbalancing:DescribeListenerCertificates",
-            "ec2:GetCoipPoolUsage",
-            "ec2:DescribeVpcs",
-            "ec2:DescribeVpcPeeringConnections",
-            "ec2:DescribeTags",
-            "ec2:DescribeSubnets",
-            "ec2:DescribeSecurityGroups",
-            "ec2:DescribeNetworkInterfaces",
-            "ec2:DescribeInternetGateways",
-            "ec2:DescribeInstances",
-            "ec2:DescribeCoipPools",
-            "ec2:DescribeAvailabilityZones",
-            "ec2:DescribeAddresses",
-            "ec2:DescribeAccountAttributes"
-          ],
-          "Effect" : "Allow",
-          "Resource" : "*"
+        "Effect" : "Allow",
+        "Resource" : "arn:aws:ec2:*:*:security-group/*"
+      },
+      {
+        "Action" : [
+          "ec2:DeleteTags",
+          "ec2:CreateTags"
+        ],
+        "Condition" : {
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "true",
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
+          }
         },
-        {
-          "Action" : [
-            "wafv2:GetWebACLForResource",
-            "wafv2:GetWebACL",
-            "wafv2:DisassociateWebACL",
-            "wafv2:AssociateWebACL",
-            "waf-regional:GetWebACLForResource",
-            "waf-regional:GetWebACL",
-            "waf-regional:DisassociateWebACL",
-            "waf-regional:AssociateWebACL",
-            "shield:GetSubscriptionState",
-            "shield:DescribeProtection",
-            "shield:DeleteProtection",
-            "shield:CreateProtection",
-            "iam:ListServerCertificates",
-            "iam:GetServerCertificate",
-            "cognito-idp:DescribeUserPoolClient",
-            "acm:ListCertificates",
-            "acm:DescribeCertificate"
-          ],
-          "Effect" : "Allow",
-          "Resource" : "*"
+        "Effect" : "Allow",
+        "Resource" : "arn:aws:ec2:*:*:security-group/*"
+      },
+      {
+        "Action" : [
+          "ec2:RevokeSecurityGroupIngress",
+          "ec2:DeleteSecurityGroup",
+          "ec2:AuthorizeSecurityGroupIngress"
+        ],
+        "Condition" : {
+          "Null" : {
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
+          }
         },
-        {
-          "Action" : [
-            "ec2:RevokeSecurityGroupIngress",
-            "ec2:AuthorizeSecurityGroupIngress"
-          ],
-          "Effect" : "Allow",
-          "Resource" : "*"
+        "Effect" : "Allow",
+        "Resource" : "*"
+      },
+      {
+        "Action" : [
+          "elasticloadbalancing:CreateTargetGroup",
+          "elasticloadbalancing:CreateLoadBalancer"
+        ],
+        "Condition" : {
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
+          }
         },
-        {
-          "Action" : "ec2:CreateSecurityGroup",
-          "Effect" : "Allow",
-          "Resource" : "*"
+        "Effect" : "Allow",
+        "Resource" : "*"
+      },
+      {
+        "Action" : [
+          "elasticloadbalancing:DeleteRule",
+          "elasticloadbalancing:DeleteListener",
+          "elasticloadbalancing:CreateRule",
+          "elasticloadbalancing:CreateListener"
+        ],
+        "Effect" : "Allow",
+        "Resource" : "*"
+      },
+      {
+        "Action" : [
+          "elasticloadbalancing:RemoveTags",
+          "elasticloadbalancing:AddTags"
+        ],
+        "Condition" : {
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "true",
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
+          }
         },
-        {
-          "Action" : "ec2:CreateTags",
-          "Condition" : {
-            "Null" : {
-              "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
-            },
-            "StringEquals" : {
-              "ec2:CreateAction" : "CreateSecurityGroup"
-            }
+        "Effect" : "Allow",
+        "Resource" : [
+          "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+        ]
+      },
+      {
+        "Action" : [
+          "elasticloadbalancing:RemoveTags",
+          "elasticloadbalancing:AddTags"
+        ],
+        "Effect" : "Allow",
+        "Resource" : [
+          "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+          "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+          "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+          "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+        ]
+      },
+      {
+        "Action" : [
+          "elasticloadbalancing:SetSubnets",
+          "elasticloadbalancing:SetSecurityGroups",
+          "elasticloadbalancing:SetIpAddressType",
+          "elasticloadbalancing:ModifyTargetGroupAttributes",
+          "elasticloadbalancing:ModifyTargetGroup",
+          "elasticloadbalancing:ModifyLoadBalancerAttributes",
+          "elasticloadbalancing:DeleteTargetGroup",
+          "elasticloadbalancing:DeleteLoadBalancer"
+        ],
+        "Condition" : {
+          "Null" : {
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        },
+        "Effect" : "Allow",
+        "Resource" : "*"
+      },
+      {
+        "Action" : "elasticloadbalancing:AddTags",
+        "Condition" : {
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
           },
-          "Effect" : "Allow",
-          "Resource" : "arn:aws:ec2:*:*:security-group/*"
+          "StringEquals" : {
+            "elasticloadbalancing:CreateAction" : [
+              "CreateTargetGroup",
+              "CreateLoadBalancer"
+            ]
+          }
         },
-        {
-          "Action" : [
-            "ec2:DeleteTags",
-            "ec2:CreateTags"
-          ],
-          "Condition" : {
-            "Null" : {
-              "aws:RequestTag/elbv2.k8s.aws/cluster" : "true",
-              "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
-            }
-          },
-          "Effect" : "Allow",
-          "Resource" : "arn:aws:ec2:*:*:security-group/*"
-        },
-        {
-          "Action" : [
-            "ec2:RevokeSecurityGroupIngress",
-            "ec2:DeleteSecurityGroup",
-            "ec2:AuthorizeSecurityGroupIngress"
-          ],
-          "Condition" : {
-            "Null" : {
-              "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
-            }
-          },
-          "Effect" : "Allow",
-          "Resource" : "*"
-        },
-        {
-          "Action" : [
-            "elasticloadbalancing:CreateTargetGroup",
-            "elasticloadbalancing:CreateLoadBalancer"
-          ],
-          "Condition" : {
-            "Null" : {
-              "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
-            }
-          },
-          "Effect" : "Allow",
-          "Resource" : "*"
-        },
-        {
-          "Action" : [
-            "elasticloadbalancing:DeleteRule",
-            "elasticloadbalancing:DeleteListener",
-            "elasticloadbalancing:CreateRule",
-            "elasticloadbalancing:CreateListener"
-          ],
-          "Effect" : "Allow",
-          "Resource" : "*"
-        },
-        {
-          "Action" : [
-            "elasticloadbalancing:RemoveTags",
-            "elasticloadbalancing:AddTags"
-          ],
-          "Condition" : {
-            "Null" : {
-              "aws:RequestTag/elbv2.k8s.aws/cluster" : "true",
-              "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
-            }
-          },
-          "Effect" : "Allow",
-          "Resource" : [
-            "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
-            "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
-            "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
-          ]
-        },
-        {
-          "Action" : [
-            "elasticloadbalancing:RemoveTags",
-            "elasticloadbalancing:AddTags"
-          ],
-          "Effect" : "Allow",
-          "Resource" : [
-            "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
-            "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
-            "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
-            "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
-          ]
-        },
-        {
-          "Action" : [
-            "elasticloadbalancing:SetSubnets",
-            "elasticloadbalancing:SetSecurityGroups",
-            "elasticloadbalancing:SetIpAddressType",
-            "elasticloadbalancing:ModifyTargetGroupAttributes",
-            "elasticloadbalancing:ModifyTargetGroup",
-            "elasticloadbalancing:ModifyLoadBalancerAttributes",
-            "elasticloadbalancing:DeleteTargetGroup",
-            "elasticloadbalancing:DeleteLoadBalancer"
-          ],
-          "Condition" : {
-            "Null" : {
-              "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
-            }
-          },
-          "Effect" : "Allow",
-          "Resource" : "*"
-        },
-        {
-          "Action" : "elasticloadbalancing:AddTags",
-          "Condition" : {
-            "Null" : {
-              "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
-            },
-            "StringEquals" : {
-              "elasticloadbalancing:CreateAction" : [
-                "CreateTargetGroup",
-                "CreateLoadBalancer"
-              ]
-            }
-          },
-          "Effect" : "Allow",
-          "Resource" : [
-            "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
-            "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
-            "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
-          ]
-        },
-        {
-          "Action" : [
-            "elasticloadbalancing:RegisterTargets",
-            "elasticloadbalancing:DeregisterTargets"
-          ],
-          "Effect" : "Allow",
-          "Resource" : "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
-        },
-        {
-          "Action" : [
-            "elasticloadbalancing:SetWebAcl",
-            "elasticloadbalancing:RemoveListenerCertificates",
-            "elasticloadbalancing:ModifyRule",
-            "elasticloadbalancing:ModifyListener",
-            "elasticloadbalancing:AddListenerCertificates"
-          ],
-          "Effect" : "Allow",
-          "Resource" : "*"
-        }
-      ]
-    })
-  }
+        "Effect" : "Allow",
+        "Resource" : [
+          "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+        ]
+      },
+      {
+        "Action" : [
+          "elasticloadbalancing:RegisterTargets",
+          "elasticloadbalancing:DeregisterTargets"
+        ],
+        "Effect" : "Allow",
+        "Resource" : "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+      },
+      {
+        "Action" : [
+          "elasticloadbalancing:SetWebAcl",
+          "elasticloadbalancing:RemoveListenerCertificates",
+          "elasticloadbalancing:ModifyRule",
+          "elasticloadbalancing:ModifyListener",
+          "elasticloadbalancing:AddListenerCertificates"
+        ],
+        "Effect" : "Allow",
+        "Resource" : "*"
+      }
+    ]
+  })
 }

--- a/iam_alb_controller.tf
+++ b/iam_alb_controller.tf
@@ -31,168 +31,177 @@ resource "aws_iam_role_policy" "albrole_policy" {
     "Version" : "2012-10-17",
     "Statement" : [
       {
-        "Action" : "iam:CreateServiceLinkedRole",
+        "Effect" : "Allow",
+        "Action" : [
+          "iam:CreateServiceLinkedRole"
+        ],
+        "Resource" : "*",
         "Condition" : {
           "StringEquals" : {
             "iam:AWSServiceName" : "elasticloadbalancing.amazonaws.com"
           }
-        },
-        "Effect" : "Allow",
-        "Resource" : "*"
+        }
       },
       {
+        "Effect" : "Allow",
         "Action" : [
-          "elasticloadbalancing:DescribeTargetHealth",
-          "elasticloadbalancing:DescribeTargetGroups",
-          "elasticloadbalancing:DescribeTargetGroupAttributes",
-          "elasticloadbalancing:DescribeTags",
-          "elasticloadbalancing:DescribeSSLPolicies",
-          "elasticloadbalancing:DescribeRules",
+          "ec2:DescribeAccountAttributes",
+          "ec2:DescribeAddresses",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeInternetGateways",
+          "ec2:DescribeVpcs",
+          "ec2:DescribeVpcPeeringConnections",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeInstances",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeTags",
+          "ec2:GetCoipPoolUsage",
+          "ec2:DescribeCoipPools",
+          "ec2:GetSecurityGroupsForVpc",
           "elasticloadbalancing:DescribeLoadBalancers",
           "elasticloadbalancing:DescribeLoadBalancerAttributes",
           "elasticloadbalancing:DescribeListeners",
           "elasticloadbalancing:DescribeListenerCertificates",
-          "ec2:GetCoipPoolUsage",
-          "ec2:DescribeVpcs",
-          "ec2:DescribeVpcPeeringConnections",
-          "ec2:DescribeTags",
-          "ec2:DescribeSubnets",
-          "ec2:DescribeSecurityGroups",
-          "ec2:DescribeNetworkInterfaces",
-          "ec2:DescribeInternetGateways",
-          "ec2:DescribeInstances",
-          "ec2:DescribeCoipPools",
-          "ec2:DescribeAvailabilityZones",
-          "ec2:DescribeAddresses",
-          "ec2:DescribeAccountAttributes"
+          "elasticloadbalancing:DescribeSSLPolicies",
+          "elasticloadbalancing:DescribeRules",
+          "elasticloadbalancing:DescribeTargetGroups",
+          "elasticloadbalancing:DescribeTargetGroupAttributes",
+          "elasticloadbalancing:DescribeTargetHealth",
+          "elasticloadbalancing:DescribeTags",
+          "elasticloadbalancing:DescribeTrustStores",
+          "elasticloadbalancing:DescribeListenerAttributes"
         ],
-        "Effect" : "Allow",
         "Resource" : "*"
       },
       {
+        "Effect" : "Allow",
         "Action" : [
-          "wafv2:GetWebACLForResource",
-          "wafv2:GetWebACL",
-          "wafv2:DisassociateWebACL",
-          "wafv2:AssociateWebACL",
-          "waf-regional:GetWebACLForResource",
-          "waf-regional:GetWebACL",
-          "waf-regional:DisassociateWebACL",
-          "waf-regional:AssociateWebACL",
-          "shield:GetSubscriptionState",
-          "shield:DescribeProtection",
-          "shield:DeleteProtection",
-          "shield:CreateProtection",
-          "iam:ListServerCertificates",
-          "iam:GetServerCertificate",
           "cognito-idp:DescribeUserPoolClient",
           "acm:ListCertificates",
-          "acm:DescribeCertificate"
+          "acm:DescribeCertificate",
+          "iam:ListServerCertificates",
+          "iam:GetServerCertificate",
+          "waf-regional:GetWebACL",
+          "waf-regional:GetWebACLForResource",
+          "waf-regional:AssociateWebACL",
+          "waf-regional:DisassociateWebACL",
+          "wafv2:GetWebACL",
+          "wafv2:GetWebACLForResource",
+          "wafv2:AssociateWebACL",
+          "wafv2:DisassociateWebACL",
+          "shield:GetSubscriptionState",
+          "shield:DescribeProtection",
+          "shield:CreateProtection",
+          "shield:DeleteProtection"
         ],
-        "Effect" : "Allow",
         "Resource" : "*"
       },
       {
+        "Effect" : "Allow",
         "Action" : [
-          "ec2:RevokeSecurityGroupIngress",
-          "ec2:AuthorizeSecurityGroupIngress"
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:RevokeSecurityGroupIngress"
         ],
-        "Effect" : "Allow",
         "Resource" : "*"
       },
       {
-        "Action" : "ec2:CreateSecurityGroup",
         "Effect" : "Allow",
-        "Resource" : "*"
-      },
-      {
-        "Action" : "ec2:CreateTags",
-        "Condition" : {
-          "Null" : {
-            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
-          },
-          "StringEquals" : {
-            "ec2:CreateAction" : "CreateSecurityGroup"
-          }
-        },
-        "Effect" : "Allow",
-        "Resource" : "arn:aws:ec2:*:*:security-group/*"
-      },
-      {
         "Action" : [
-          "ec2:DeleteTags",
+          "ec2:CreateSecurityGroup"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
           "ec2:CreateTags"
         ],
+        "Resource" : "arn:aws:ec2:*:*:security-group/*",
+        "Condition" : {
+          "StringEquals" : {
+            "ec2:CreateAction" : "CreateSecurityGroup"
+          },
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:CreateTags",
+          "ec2:DeleteTags"
+        ],
+        "Resource" : "arn:aws:ec2:*:*:security-group/*",
         "Condition" : {
           "Null" : {
             "aws:RequestTag/elbv2.k8s.aws/cluster" : "true",
             "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
           }
-        },
-        "Effect" : "Allow",
-        "Resource" : "arn:aws:ec2:*:*:security-group/*"
+        }
       },
       {
+        "Effect" : "Allow",
         "Action" : [
+          "ec2:AuthorizeSecurityGroupIngress",
           "ec2:RevokeSecurityGroupIngress",
-          "ec2:DeleteSecurityGroup",
-          "ec2:AuthorizeSecurityGroupIngress"
+          "ec2:DeleteSecurityGroup"
         ],
+        "Resource" : "*",
         "Condition" : {
           "Null" : {
             "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
           }
-        },
-        "Effect" : "Allow",
-        "Resource" : "*"
+        }
       },
       {
+        "Effect" : "Allow",
         "Action" : [
-          "elasticloadbalancing:CreateTargetGroup",
-          "elasticloadbalancing:CreateLoadBalancer"
+          "elasticloadbalancing:CreateLoadBalancer",
+          "elasticloadbalancing:CreateTargetGroup"
         ],
+        "Resource" : "*",
         "Condition" : {
           "Null" : {
             "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
           }
-        },
-        "Effect" : "Allow",
-        "Resource" : "*"
+        }
       },
       {
+        "Effect" : "Allow",
         "Action" : [
-          "elasticloadbalancing:DeleteRule",
+          "elasticloadbalancing:CreateListener",
           "elasticloadbalancing:DeleteListener",
           "elasticloadbalancing:CreateRule",
-          "elasticloadbalancing:CreateListener"
+          "elasticloadbalancing:DeleteRule"
         ],
-        "Effect" : "Allow",
         "Resource" : "*"
       },
       {
-        "Action" : [
-          "elasticloadbalancing:RemoveTags",
-          "elasticloadbalancing:AddTags"
-        ],
-        "Condition" : {
-          "Null" : {
-            "aws:RequestTag/elbv2.k8s.aws/cluster" : "true",
-            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
-          }
-        },
         "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:RemoveTags"
+        ],
         "Resource" : [
           "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
           "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
           "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
-        ]
+        ],
+        "Condition" : {
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "true",
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
       },
       {
-        "Action" : [
-          "elasticloadbalancing:RemoveTags",
-          "elasticloadbalancing:AddTags"
-        ],
         "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:RemoveTags"
+        ],
         "Resource" : [
           "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
           "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
@@ -201,61 +210,64 @@ resource "aws_iam_role_policy" "albrole_policy" {
         ]
       },
       {
+        "Effect" : "Allow",
         "Action" : [
-          "elasticloadbalancing:SetSubnets",
-          "elasticloadbalancing:SetSecurityGroups",
-          "elasticloadbalancing:SetIpAddressType",
-          "elasticloadbalancing:ModifyTargetGroupAttributes",
-          "elasticloadbalancing:ModifyTargetGroup",
           "elasticloadbalancing:ModifyLoadBalancerAttributes",
+          "elasticloadbalancing:SetIpAddressType",
+          "elasticloadbalancing:SetSecurityGroups",
+          "elasticloadbalancing:SetSubnets",
+          "elasticloadbalancing:DeleteLoadBalancer",
+          "elasticloadbalancing:ModifyTargetGroup",
+          "elasticloadbalancing:ModifyTargetGroupAttributes",
           "elasticloadbalancing:DeleteTargetGroup",
-          "elasticloadbalancing:DeleteLoadBalancer"
+          "elasticloadbalancing:ModifyListenerAttributes"
         ],
+        "Resource" : "*",
         "Condition" : {
           "Null" : {
             "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
           }
-        },
-        "Effect" : "Allow",
-        "Resource" : "*"
+        }
       },
       {
-        "Action" : "elasticloadbalancing:AddTags",
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:AddTags"
+        ],
+        "Resource" : [
+          "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+        ],
         "Condition" : {
-          "Null" : {
-            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
-          },
           "StringEquals" : {
             "elasticloadbalancing:CreateAction" : [
               "CreateTargetGroup",
               "CreateLoadBalancer"
             ]
+          },
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
           }
-        },
-        "Effect" : "Allow",
-        "Resource" : [
-          "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
-          "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
-          "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
-        ]
+        }
       },
       {
+        "Effect" : "Allow",
         "Action" : [
           "elasticloadbalancing:RegisterTargets",
           "elasticloadbalancing:DeregisterTargets"
         ],
-        "Effect" : "Allow",
         "Resource" : "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
       },
       {
+        "Effect" : "Allow",
         "Action" : [
           "elasticloadbalancing:SetWebAcl",
-          "elasticloadbalancing:RemoveListenerCertificates",
-          "elasticloadbalancing:ModifyRule",
           "elasticloadbalancing:ModifyListener",
-          "elasticloadbalancing:AddListenerCertificates"
+          "elasticloadbalancing:AddListenerCertificates",
+          "elasticloadbalancing:RemoveListenerCertificates",
+          "elasticloadbalancing:ModifyRule"
         ],
-        "Effect" : "Allow",
         "Resource" : "*"
       }
     ]

--- a/main.tf
+++ b/main.tf
@@ -11,16 +11,16 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "20.13.1"
 
-  cluster_name                   = var.cluster_name
-  cluster_version                = try(local.cluster_version, var.cluster_version)
+  cluster_name    = var.cluster_name
+  cluster_version = try(local.cluster_version, var.cluster_version)
 
   # Terraform identity admin access to cluster wich will allow deploying resources (Karpenter) into the cluster.
   enable_cluster_creator_admin_permissions = true
   cluster_endpoint_public_access           = true
-  authentication_mode = "API_AND_CONFIG_MAP"
+  authentication_mode                      = "API_AND_CONFIG_MAP"
 
-  vpc_id     = var.vpc_id
-  subnet_ids = data.aws_subnets.nonexpose.ids
+  vpc_id                   = var.vpc_id
+  subnet_ids               = data.aws_subnets.nonexpose.ids
   control_plane_subnet_ids = data.aws_subnets.nonexpose.ids
   # Fargate profiles use the cluster primary security group so these are not utilized
   create_cluster_security_group = var.enable_node_group == true ? true : false

--- a/outputs.tf
+++ b/outputs.tf
@@ -209,3 +209,7 @@ output "crossplane_role" {
 output "albcontroller_role" {
   value = aws_iam_role.albrole[*].arn
 }
+
+output "albcontroller_role_policy" {
+  value = aws_iam_role_policy.albrole_policy[*].arn
+}

--- a/values.tf
+++ b/values.tf
@@ -9,7 +9,7 @@ locals {
   argorollouts_ingress  = var.argorollouts_ingress_name == null ? "k8s-argo-ro-${var.name_service}-${local.env}${random_string.default.result}" : var.argorollouts_ingress_name
   dns_suffix            = data.aws_partition.current.dns_suffix
   partition             = data.aws_partition.current.partition
-  account_dev = setunion( var.enable_node_group ? [] : [], [
+  account_dev = setunion(var.enable_node_group ? [] : [], [
     {
       rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/AWSGSDevOpsRole"
       username = "devops-role"
@@ -22,7 +22,7 @@ locals {
       groups   = ["system:masters"]
     }
   ])
-  account_prd = setunion( var.enable_node_group ? [] : [], [
+  account_prd = setunion(var.enable_node_group ? [] : [], [
     {
       rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/AWSGSDevOpsRole"
       username = "devops-role"

--- a/variables.tf
+++ b/variables.tf
@@ -208,9 +208,9 @@ variable "argo_rollouts_version" {
 }
 
 variable "enable_node_group" {
-default = false
+  default = false
 }
 variable "manage_node_group" {
-  type        = any
+  type    = any
   default = {}
 }


### PR DESCRIPTION
This pull request includes significant changes to the IAM policy structure for the ALB controller in the `iam_alb_controller.tf` file. The changes involve splitting the inline policy (deprecated) into a separate `aws_iam_role_policy` resource and restructuring the policy statements for better clarity and management. Additionally, a new output for the ALB controller role policy ARN has been added to the `outputs.tf` file.

### IAM Policy Restructuring:

* Split the inline policy from `aws_iam_role` into a separate `aws_iam_role_policy` resource for better management and clarity. (`iam_alb_controller.tf`)
* Reorganized policy statements to include explicit `Effect` fields and grouped actions logically. (`iam_alb_controller.tf`)
* Added missing actions and conditions to ensure comprehensive permissions for the ALB controller. (`iam_alb_controller.tf`)

### Outputs:

* Added a new output for the ALB controller role policy ARN to `outputs.tf` to facilitate access to the policy ARN. (`outputs.tf`)